### PR TITLE
Improve webdirect-runtime skill discoverability

### DIFF
--- a/.changeset/webdirect-skill-discoverability.md
+++ b/.changeset/webdirect-skill-discoverability.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/webviewer": patch
+---
+
+Make webdirect-runtime skill discoverable for encoding/blank-app issues: description now leads with blank/empty WebDirect page and character encoding (UTF-8, Unicode, emoji, special characters, deploy_html) keywords; troubleshooting section names `deploy_html` and common non-ASCII culprits.

--- a/packages/webviewer/skills/webdirect-runtime/SKILL.md
+++ b/packages/webviewer/skills/webdirect-runtime/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: webdirect-runtime
 description: >
-  FileMaker WebDirect ProofKit Web Viewer runtime behavior refresh resilience
-  session state localStorage browser resize reload same deployment embedded bundle
-  avoid separate deployment avoid separate web server @proofkit/webviewer
-  fmFetch callFMScript WebViewerAdapter WebDirect page refresh blank app empty body
-  character encoding browser network response console errors deployed HTML
+  Troubleshoot and build FileMaker WebDirect ProofKit Web Viewer apps. Load when a Web Viewer
+  app is blank, white, or empty in WebDirect, when the WebDirect page response has an empty
+  body, when deployed HTML is garbled, mangled, or corrupted, or when diagnosing character
+  encoding, UTF-8, Unicode, mojibake, emoji, accented, curly quote, or other special or
+  non-ASCII characters in the single-file HTML written by the deploy_html FileMaker script.
+  Also covers refresh resilience, unexpected page reload from browser resize, session state
+  in localStorage, bundle size and page-weight myths, running the same embedded bundle in
+  WebDirect and FileMaker Pro without a separate deployment or web server, and browser
+  console and network diagnosis with @proofkit/webviewer fmFetch callFMScript
+  WebViewerAdapter.
 metadata:
   type: core
   library: proofkit
@@ -48,7 +53,7 @@ When a web app doesn't load in WebDirect, inspect what the browser received befo
 3. Check the browser console for parse errors, runtime exceptions, blocked resources, or security errors.
 4. Distinguish an empty WebDirect page response from an empty rendered root element inside the Web Viewer. React can start with an empty root and populate it at runtime, so the DOM alone doesn't prove that WebDirect omitted the bundle.
 
-If the complete page served by WebDirect has an empty body and the Web Viewer bundle is absent from that response, suspect character encoding first. An incorrectly encoded or unsupported character in the deployed single-file HTML can cause WebDirect to return an empty body instead of sending the bundle. Inspect the built HTML for invalid UTF-8 or problematic characters, rebuild, redeploy, and check the full WebDirect response again.
+If the complete page served by WebDirect has an empty body and the Web Viewer bundle is absent from that response, suspect character encoding first. An incorrectly encoded or unsupported character in the deployed single-file HTML — the payload the `deploy_html` FileMaker script writes into the file — can cause WebDirect to return an empty body instead of sending the bundle. Non-ASCII content such as emoji, curly quotes, accented letters, or invalid UTF-8 sequences is the usual source. Inspect the built HTML for invalid UTF-8 or problematic characters, rebuild, redeploy via `deploy_html`, and check the full WebDirect response again.
 
 If the full WebDirect response contains the Web Viewer HTML and JavaScript bundle, don't keep treating encoding or bundle size as the default cause. Follow the browser's console and network evidence to the parse, runtime, bridge, or security failure.
 


### PR DESCRIPTION
Community report: an agent debugging a blank WebDirect app never found the `webdirect-runtime` skill's encoding guidance. Its `intent list` output showed no skill title/description mentioning encoding, Unicode, `deploy_html`, or content corruption.

The content existed (shipped in `@proofkit/webviewer@3.3.0`, commit 7ba2d6df) but wasn't routable: "character encoding" sat last in a keyword blob, and `UTF-8`, `Unicode`, `blank screen`, `corrupted`, `emoji`, `special characters`, and `deploy_html` appeared nowhere in the skill.

## Changes

- **Description** rewritten as a dense routing key per the intent `generate-skill` spec: leads with the symptom (blank/white/empty WebDirect app, empty page body, garbled/corrupted deployed HTML) and names UTF-8, Unicode, mojibake, emoji, accented, curly quote, non-ASCII, `deploy_html`. Refresh/state/bundle-size keywords retained, moved after.
- **Troubleshooting section** names `deploy_html` as the script writing the single-file HTML payload, and lists the usual non-ASCII culprits.

Changeset added (patch).

`intent validate` passes; `pnpm run ci` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded WebDirect troubleshooting guidance for blank pages, corrupted HTML, and character encoding issues.
  * Added guidance for diagnosing `deploy_html`-generated HTML responses and non-ASCII character problems.
  * Clarified recommended rebuild, redeploy, and response-verification steps.
* **Release**
  * Prepared a patch release for the web viewer package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->